### PR TITLE
Replacing Obsolete WWW with UnityWebRequest

### DIFF
--- a/Davinci/Assets/Davinci/Scripts/Davinci.cs
+++ b/Davinci/Assets/Davinci/Scripts/Davinci.cs
@@ -6,6 +6,9 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
+#if UNITY_2018_3_OR_NEWER
+using UnityEngine.Networking;
+#endif
 
 /// <summary>
 /// Davinci - A powerful, esay-to-use image downloading and caching library for Unity in Run-Time
@@ -321,7 +324,12 @@ public class Davinci : MonoBehaviour
         if (enableLog)
             Debug.Log("[Davinci] Download started.");
 
+#if UNITY_2018_3_OR_NEWER
+        UnityWebRequest www = UnityWebRequestTexture.GetTexture(url);
+        yield return www.SendWebRequest();
+#else
         var www = new WWW(url);
+#endif
 
         while (!www.isDone)
         {
@@ -331,7 +339,11 @@ public class Davinci : MonoBehaviour
                 yield break;
             }
 
+#if UNITY_2018_3_OR_NEWER
+            progress = Mathf.FloorToInt(www.downloadProgress * 100);
+#else
             progress = Mathf.FloorToInt(www.progress * 100);
+#endif
             if (onDownloadProgressChange != null)
                 onDownloadProgressChange.Invoke(progress);
 
@@ -341,8 +353,13 @@ public class Davinci : MonoBehaviour
             yield return null;
         }
 
+#if UNITY_2018_3_OR_NEWER
+        if (www.error == null)
+            File.WriteAllBytes(filePath + uniqueHash, www.downloadHandler.data);
+#else
         if (www.error == null)
             File.WriteAllBytes(filePath + uniqueHash, www.bytes);
+#endif
 
         www.Dispose();
         www = null;


### PR DESCRIPTION
Obsolete: WWW has been replaced with UnityWebRequest.
This change is compatible with Unity versions older than 2018.3